### PR TITLE
Add minimum shared library version check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,6 @@ jobs:
   build-wheel:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    environment: pypi-deployment
     strategy:
       matrix:
         os: [macos-13, ubuntu-latest, windows-latest]

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -1,7 +1,9 @@
 name: "Sphinx: Render docs"
 
-on: push
-
+on:
+  push:
+    branches:
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,10 +16,10 @@ jobs:
 
     - name: Get MOPAC shared library
       run: |
-        curl -OL https://github.com/openmopac/mopac/releases/download/v23.1.2/mopac-23.1.2-linux.tar.gz
-        tar -xvzf mopac-23.1.2-linux.tar.gz
+        curl -OL https://github.com/openmopac/mopac/releases/download/v23.2/mopac-23.2-linux.tar.gz
+        tar -xvzf mopac-23.2-linux.tar.gz
         mkdir src/mopactools/lib
-        cp mopac-23.1.2-linux/lib/* src/mopactools/lib
+        cp mopac-23.2-linux/lib/* src/mopactools/lib
 
     - name: Build HTML
       uses: ammaraskar/sphinx-action@master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mopactools"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name="Jonathan Moussa", email="jemoussa@vt.edu" },
 ]
@@ -23,6 +23,7 @@ license = { text="Apache-2.0" }
 dependencies = [
     "numpy",
     "scipy",
+    "packaging",
 ]
 
 [project.urls]

--- a/src/mopactools/api.py
+++ b/src/mopactools/api.py
@@ -19,6 +19,7 @@ import math
 import ctypes
 import numpy as np
 import scipy
+from packaging.version import Version, InvalidVersion
 from . import binding
 
 class MopacSystem:
@@ -646,4 +647,9 @@ buffer = ctypes.create_string_buffer(21)
 binding.libmopac.get_mopac_version(buffer)
 #: Semantic version number of the MOPAC shared library
 VERSION = buffer.value.decode('utf-8')
-# In the future, it might make sense to put a minimum version test here
+MIN_VERSION = "23.2"
+try:
+    if Version(VERSION) < Version(MIN_VERSION):
+        raise ValueError(f"MOPAC shared library version ({VERSION}) is older than the minimum required version ({MIN_VERSION}).")
+except InvalidVersion:
+    print(f"WARNING: MOPAC shared library has a non-standard version ({VERSION}) and might not be compatible with mopactools.")


### PR DESCRIPTION
This is a patch version bump that adds a shared library version check as a new minor feature and updates the MOPAC version to fix some API bugs that were discovered and fixed in the previous version.