### PR TITLE
Fixed mozyme initialization

### DIFF
--- a/src/mopactools/api.py
+++ b/src/mopactools/api.py
@@ -421,9 +421,10 @@ class MozymeState:
                 raise TypeError("mismatch between MozymeState and c_mozyme_state")
             self._as_parameter_ = ctypes.pointer(c_state)
             self.update()
+
     def attach(self):
         if self._as_parameter_ is None:
-            self._as_parameter_ = ctypes.pointer(binding.c_mopac_state())
+            self._as_parameter_ = ctypes.pointer(binding.c_mozyme_state())
             self._as_parameter_[0].numat = self.numat
             self._as_parameter_[0].noccupied = len(self.ncf)
             self._as_parameter_[0].nvirtual = len(self.nce)


### PR DESCRIPTION
Adapting the example to using mozyme did not work, there was a bug in `MozymeState.attach()` where binding.c_mopac_state was used instead of binding.c_mozyme_state.

After fixing this, the example can be calculated with mozyme.